### PR TITLE
Add official docs link to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nwjs/nw.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)  
 Official site: http://nwjs.io  
+Official documentation: http://docs.nwjs.io/  
 [Announcement](https://groups.google.com/d/msg/nwjs-general/V1FhvfaFIzQ/720xKVd0jNkJ)  
 ## Introduction
 


### PR DESCRIPTION
There is no link to the docs in the repo, I thought it would be useful to add it.